### PR TITLE
Fixed null entity call with Geckolib

### DIFF
--- a/src/main/java/io/github/apace100/cosmetic_armor/DeferredRenderList.java
+++ b/src/main/java/io/github/apace100/cosmetic_armor/DeferredRenderList.java
@@ -1,0 +1,8 @@
+package io.github.apace100.cosmetic_armor;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public interface DeferredRenderList {
+	List<Supplier<Boolean>> deferredRenderList();
+}

--- a/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorDeferredRender.java
+++ b/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorDeferredRender.java
@@ -1,0 +1,35 @@
+package io.github.apace100.cosmetic_armor.mixin;
+
+import java.util.function.Supplier;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import io.github.apace100.cosmetic_armor.DeferredRenderList;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.feature.ArmorFeatureRenderer;
+import net.minecraft.client.render.entity.feature.FeatureRenderer;
+import net.minecraft.client.render.entity.feature.FeatureRendererContext;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.LivingEntity;
+
+@Environment(EnvType.CLIENT)
+@Mixin(value = ArmorFeatureRenderer.class, priority = 600)
+public abstract class MixinCosmeticArmorDeferredRender<T extends LivingEntity, M extends BipedEntityModel<T>, A extends BipedEntityModel<T>> extends FeatureRenderer<T, M> implements DeferredRenderList {
+	
+	public MixinCosmeticArmorDeferredRender(FeatureRendererContext<T, M> context) {
+		super(context);
+	}
+	
+	@Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/entity/LivingEntity;FFFFFF)V", at = @At("TAIL"))
+	private void renderDelayed(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
+		var deferredRenderList = this.deferredRenderList();
+		deferredRenderList.forEach(Supplier::get);
+		deferredRenderList.clear();
+	}
+}

--- a/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java
+++ b/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java
@@ -1,6 +1,7 @@
 package io.github.apace100.cosmetic_armor.mixin;
 
 import io.github.apace100.cosmetic_armor.CosmeticArmor;
+import io.github.apace100.cosmetic_armor.DeferredRenderList;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.rendering.v1.ArmorRenderer;
@@ -34,7 +35,7 @@ import java.util.function.Supplier;
 
 @Environment(EnvType.CLIENT)
 @Mixin(value = ArmorFeatureRenderer.class, priority = 800)
-public abstract class MixinCosmeticArmorVisibility<T extends LivingEntity, M extends BipedEntityModel<T>, A extends BipedEntityModel<T>> extends FeatureRenderer<T, M> {
+public abstract class MixinCosmeticArmorVisibility<T extends LivingEntity, M extends BipedEntityModel<T>, A extends BipedEntityModel<T>> extends FeatureRenderer<T, M> implements DeferredRenderList {
 
 	@Shadow protected abstract void setVisible(A bipedModel, EquipmentSlot slot);
 
@@ -75,12 +76,6 @@ public abstract class MixinCosmeticArmorVisibility<T extends LivingEntity, M ext
 		}
 	}
 
-	@Inject(method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;ILnet/minecraft/entity/LivingEntity;FFFFFF)V", at = @At("TAIL"))
-	private void renderDelayed(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l, CallbackInfo ci) {
-		cosmeticarmor$renderList.forEach(Supplier::get);
-		cosmeticarmor$renderList.clear();
-	}
-
 	@Redirect(method = "renderArmor", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;getEquippedStack(Lnet/minecraft/entity/EquipmentSlot;)Lnet/minecraft/item/ItemStack;"))
 	private ItemStack modifyVisibleArmor(LivingEntity entity, EquipmentSlot slot) {
 		ItemStack equippedStack = entity.getEquippedStack(slot);
@@ -114,5 +109,10 @@ public abstract class MixinCosmeticArmorVisibility<T extends LivingEntity, M ext
 		} else {
 			this.renderArmorParts(matrices, vertexConsumers, light, armorItem, bl2, model, bl, 1.0f, 1.0f, 1.0f, null);
 		}
+	}
+	
+	@Override
+	public List<Supplier<Boolean>> deferredRenderList() {
+		return this.cosmeticarmor$renderList;
 	}
 }

--- a/src/main/resources/cosmetic-armor.mixins.json
+++ b/src/main/resources/cosmetic-armor.mixins.json
@@ -7,6 +7,7 @@
   ],
   "client": [
     "MixinCosmeticArmorVisibility",
+    "MixinCosmeticArmorDeferredRender",
     "MixinCosmeticHeadVisibility"
   ],
   "injectors": {


### PR DESCRIPTION
### 1.0 Issue

When run with Geckolib and any mod that uses Fabric API's [ArmorRenderer](https://github.com/FabricMC/fabric/blob/1.19.4/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java), Geckolib's [`gl_storedEntity`](https://github.com/bernie-g/geckolib/blob/1c32007de19519b3c045e8cc9935694ec3ac930e/Fabric/src/main/java/software/bernie/geckolib3/mixins/fabric/MixinArmorFeatureRenderer.java#L38) can be null and cause a crash.

An example of this behaviour is available [here](https://github.com/CleverNucleus/RelicEx/issues/34) - this is also why I am submitting this merge request, as it is my mod that brings this bug to the surface.

### 2.0 Cause

Geckolib stores a reference to the entity by caching it at the start/header of [`ArmorFeatureRenderer#render`](https://github.com/bernie-g/geckolib/blob/1c32007de19519b3c045e8cc9935694ec3ac930e/Fabric/src/main/java/software/bernie/geckolib3/mixins/fabric/MixinArmorFeatureRenderer.java#L47), and discards the reference (sets it to null) at the end of said method. Geckolib's Mixin priority for this is `700`.

Cosmetic Armor is deferring the render logic at [`ArmorFeatureRenderer#renderArmor`](https://github.com/apace100/cosmetic-armor/blob/e40a66fdedc363d2bfd520f8178ea61827fa559c/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java#L53) and then running that deferred rendering at the end of [`ArmorFeatureRenderer#render`](https://github.com/apace100/cosmetic-armor/blob/e40a66fdedc363d2bfd520f8178ea61827fa559c/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java#L78). Cosmetic Armor's Mixin priority for this is `800`.

This means that Cosmetic Armor defers any Fabric API `ArmorRenderer` rendering to **after** Geckolib sets its cached entity reference to null - i.e., rendering is happening when Geckolib's [`gl_storedEntity`](https://github.com/bernie-g/geckolib/blob/1c32007de19519b3c045e8cc9935694ec3ac930e/Fabric/src/main/java/software/bernie/geckolib3/mixins/fabric/MixinArmorFeatureRenderer.java#L38) is null. Because Geckolib has some *fairly* intrusive mixins in `ArmorFeatureRenderer`, any rendering that occurs **must** occur when [`gl_storedEntity`](https://github.com/bernie-g/geckolib/blob/1c32007de19519b3c045e8cc9935694ec3ac930e/Fabric/src/main/java/software/bernie/geckolib3/mixins/fabric/MixinArmorFeatureRenderer.java#L38) is not null, and references the correct entity.

Hence, mods (in this case, my mod) that utilise Fabric API's `ArmorRenderer` will cause the game to crash when used in conjunction with Cosmetic Armor and Geckolib.

### 3.0 Solution

#### 3.1 Setting Mixin Priority

The immediate fix would seem to be to just set the Mixin priority for Cosmetic Armor to something less than `700`. Indeed, this seems to resolve the issue; however, as setting the priority to `800` is obviously deliberate, I was unsure that there wasn't perhaps another reason for this - so I left it and produced a different solution.

If there is no other reason to keep the priority at `800`, then just putting it to less than `700` fixes everything discussed above.

#### 3.2 Splitting Mixin Priority

The alternative solution - and the one I have offered here in the merge request - is to split the `ArmorFeatureRenderer` mixin into two and give them separate priorities.

What I have done here is create an interface to access [`cosmeticarmor$renderList`](https://github.com/apace100/cosmetic-armor/blob/e40a66fdedc363d2bfd520f8178ea61827fa559c/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java#L46) and have the mixin implement that. I have then created another `ArmorFeatureRenderer` mixin and moved the inject method [`ArmorFeatureRenderer#render`](https://github.com/apace100/cosmetic-armor/blob/e40a66fdedc363d2bfd520f8178ea61827fa559c/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java#L78) from the original Mixin class to the newly created one. I then had it such that instead of calling the field [`cosmeticarmor$renderList`](https://github.com/apace100/cosmetic-armor/blob/e40a66fdedc363d2bfd520f8178ea61827fa559c/src/main/java/io/github/apace100/cosmetic_armor/mixin/MixinCosmeticArmorVisibility.java#L80), it just called the interface getter method for access.

Naturally, the added Mixin class had its priority set to less than `700` (in this case, it was set to `600`) and the original Mixin class' priority remained unchanged. This means that Geckolib's [`gl_storedEntity`](https://github.com/bernie-g/geckolib/blob/1c32007de19519b3c045e8cc9935694ec3ac930e/Fabric/src/main/java/software/bernie/geckolib3/mixins/fabric/MixinArmorFeatureRenderer.java#L38) is no longer null because Cosmetic Armor's deferred rendering implementation now gets called *just* before `gl_storedEntity` gets set to null.

### 4.0 Conclusion

This was fairly tricky to diagnose at first - since the crash only occurred when my mod was installed - turns out, it is any mod that uses Fabric API's `ArmorRenderer`. Admittedly, few mods use this part of Fabric API so it is unsurprising that this issue has slipped by as it is only apparent when rare conditions are met.

Regardless of if this is merged or not, I would still urge you to implement either of the fixes I have suggested (or any other fix), as this is a technical incompatibility with Fabric API.

Hope that's all okay; I'm sure it goes without saying but I love Cosmetic Armor - that is why I have put in the effort here!

Thanks.